### PR TITLE
Remove 'string-interpolate' dependency

### DIFF
--- a/src/Taskwarrior/Mask.hs
+++ b/src/Taskwarrior/Mask.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE LambdaCase, QuasiQuotes #-}
--- | The Mask module models the state a recurring parent saves about it‘s child tasks.
+{-# LANGUAGE LambdaCase #-}
+-- | The Mask module models the state a recurring parent saves about its child tasks.
 module Taskwarrior.Mask
   ( Mask(..)
   , MaskState
@@ -7,7 +7,6 @@ module Taskwarrior.Mask
 where
 
 import qualified Data.Text                     as Text
-import           Data.String.Interpolate        ( i )
 import qualified Data.Aeson                    as Aeson
 import qualified Data.Aeson.Types              as Aeson.Types
 
@@ -34,7 +33,7 @@ parseChar = \case
   '+'  -> pure Completed
   'X'  -> pure Deleted
   'W'  -> pure Waiting
-  char -> fail [i|Not a Mask Char: '#{char}'|]
+  char -> fail $ "Not a Mask Char: '"++[char]++"'"
 
 instance Aeson.ToJSON Mask where
   toJSON = Aeson.String . Text.pack . fmap toChar . mask

--- a/taskwarrior.cabal
+++ b/taskwarrior.cabal
@@ -35,7 +35,6 @@ library
   default-extensions:
     LambdaCase
     OverloadedStrings
-    QuasiQuotes
     RecordWildCards
 
   build-depends:

--- a/taskwarrior.cabal
+++ b/taskwarrior.cabal
@@ -44,7 +44,6 @@ library
     , bytestring            ^>=0.10.8.2
     , process               ^>=1.6.5.0
     , random                ^>=1.1
-    , string-interpolate    >=0.1.0.0  && <0.3
     , text                  ^>=1.2.3.1
     , time                  >=1.8.0.2  && <1.10
     , unordered-containers  ^>=0.2.9.0


### PR DESCRIPTION
Note we say:

```haskell
"Not a Mask Char: '"++[char]++"'"
```

So that e.g. a char like `ǚ` will show as `"Not a Mask Char: 'ǚ'"`.

If we'd said `"Not a Mask Char: "++show char`, it'd be `"Not a Mask Char:  '\474'"`