### PR TITLE
In masks, allow '-', which means the task is pending

### DIFF
--- a/src/Taskwarrior/Mask.hs
+++ b/src/Taskwarrior/Mask.hs
@@ -30,6 +30,7 @@ instance Aeson.FromJSON Mask where
 parseChar :: Char -> Aeson.Types.Parser MaskState
 parseChar = \case
   '.'  -> pure Pending
+  '-'  -> pure Pending
   '+'  -> pure Completed
   'X'  -> pure Deleted
   'W'  -> pure Waiting

--- a/src/Taskwarrior/Mask.hs
+++ b/src/Taskwarrior/Mask.hs
@@ -18,7 +18,7 @@ newtype Mask = Mask {mask :: [MaskState]} deriving (Eq, Read, Ord, Show)
 
 toChar :: MaskState -> Char
 toChar = \case
-  Pending   -> '.'
+  Pending   -> '-'
   Completed -> '+'
   Deleted   -> 'X'
   Waiting   -> 'W'
@@ -29,7 +29,6 @@ instance Aeson.FromJSON Mask where
 
 parseChar :: Char -> Aeson.Types.Parser MaskState
 parseChar = \case
-  '.'  -> pure Pending
   '-'  -> pure Pending
   '+'  -> pure Completed
   'X'  -> pure Deleted


### PR DESCRIPTION
I wasn't actually able to find any `.` characters in my tasks, and it looks like [the docs](https://taskwarrior.org/docs/recurrence.html) don't mention `.`.  Should I switch `.` to `-` in the other places in `Taskwarrior.Mask`, or are both acceptable in some version(s) of taskwarrior?