### PR TITLE
Only export id and urgency if not 0

### DIFF
--- a/src/Taskwarrior/Task.hs
+++ b/src/Taskwarrior/Task.hs
@@ -157,7 +157,7 @@ instance ToJSON Task where
          , "entry" .= Time.toValue entry
          , "description" .= description
          ]
-      <> (if urgency == 0 then [] else ["urgency" .= urgency])
+      <> [ "urgency" .= urgency | not (urgency == 0) ]
       <> maybe [] RecurringChild.toPairs recurringChild
       <> ifNotNullList annotations ("annotations" .=)
       <> Maybe.mapMaybe

--- a/src/Taskwarrior/Task.hs
+++ b/src/Taskwarrior/Task.hs
@@ -157,7 +157,7 @@ instance ToJSON Task where
          , "entry" .= Time.toValue entry
          , "description" .= description
          ]
-      <> [ "urgency" .= urgency | not (urgency == 0) ]
+      <> [ "urgency" .= urgency | urgency /= 0 ]
       <> maybe [] RecurringChild.toPairs recurringChild
       <> ifNotNullList annotations ("annotations" .=)
       <> Maybe.mapMaybe

--- a/src/Taskwarrior/Task.hs
+++ b/src/Taskwarrior/Task.hs
@@ -154,11 +154,10 @@ instance ToJSON Task where
     Aeson.object
       $  Status.toPairs status
       <> [ "uuid" .= uuid
-         , "id" .= fromMaybe 0 id
          , "entry" .= Time.toValue entry
          , "description" .= description
-         , "urgency" .= urgency
          ]
+      <> (if urgency == 0 then [] else ["urgency" .= urgency])
       <> maybe [] RecurringChild.toPairs recurringChild
       <> ifNotNullList annotations ("annotations" .=)
       <> Maybe.mapMaybe
@@ -170,7 +169,10 @@ instance ToJSON Task where
            , ("until"    , until_)
            ]
       <> Maybe.catMaybes
-           [("project" .=) <$> project, ("priority" .=) <$> priority]
+           [ ("id" .=) <$> id
+           , ("project" .=) <$> project
+           , ("priority" .=) <$> priority
+           ]
       <> ifNotNullList
            depends
            (("depends" .=) . Text.intercalate "," . fmap UUID.toText)


### PR DESCRIPTION
I prefer the json serialization to not include unnecessary fields. In my
tooling parsing a Task with id or urgency and then serializing it again
would lead to the generation of a previous not existing and unnecessary
id or urgency field.

@ryantrinkle Can you have a quick look at this, if you think this change would
break your tooling? It‘s okay if you don‘t care. Then I will just merge it.